### PR TITLE
Don't write wasm in place

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owasm-utils-cli"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>", "Oasis Labs <info@oasislabs.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/oasislabs/owasm-utils"


### PR DESCRIPTION
this fixes a bug where multiple builds of the same wasm would overwrite each other. multiple builds of the same wasm happen when running the build script of a contract that invokes another contract's build script.